### PR TITLE
 CFT-3283 Prevent Fix field larger than field limit errors

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -5,28 +5,29 @@ Template Component main class.
 import asyncio
 import csv
 import dataclasses
-import logging
-from typing import List
 import json
+import logging
 import os
+import sys
 from io import StringIO
 from itertools import islice
+from typing import List
+
 import pystache as pystache
 import requests.exceptions
-
+from kbcstorage.client import Client
+from kbcstorage.tables import Tables
 from keboola.component.base import ComponentBase, sync_action
-from keboola.component.sync_actions import ValidationResult, MessageType
 from keboola.component.dao import TableDefinition
 from keboola.component.exceptions import UserException
-from kbcstorage.tables import Tables
-from kbcstorage.client import Client
+from keboola.component.sync_actions import ValidationResult, MessageType
 
-from configuration import Configuration
-from client.openai_client import OpenAIClient, AzureOpenAIClient
-from client.googleai_client import GoogleAIClient
-from client.base import AIClientException
-from client.huggingface_client import HuggingfaceClient
 from client.anthropic_client import AnthropicClient
+from client.base import AIClientException
+from client.googleai_client import GoogleAIClient
+from client.huggingface_client import HuggingfaceClient
+from client.openai_client import OpenAIClient, AzureOpenAIClient
+from configuration import Configuration
 
 # configuration variables
 RESULT_COLUMN_NAME = 'result_value'
@@ -47,6 +48,10 @@ PREVIEW_LIMIT = 5
 BATCH_SIZE = 10
 LOG_EVERY = 100
 PROMPT_TEMPLATES = 'templates/prompts.json'
+
+# to prevent field larger than field limit (131072) Errors
+# https://stackoverflow.com/questions/15063936/csv-error-field-larger-than-field-limit-131072
+csv.field_size_limit(sys.maxsize)
 
 
 class Component(ComponentBase):
@@ -371,7 +376,7 @@ class Component(ComponentBase):
     def count_rows(file_path):
         with open(file_path, 'r', encoding='utf-8') as file:
             reader = csv.reader(file)
-            row_count = sum(1 for _ in reader)-1
+            row_count = sum(1 for _ in reader) - 1
         return row_count
 
     @sync_action('listPkeys')


### PR DESCRIPTION
This pull request makes changes to the `src/component.py` file, primarily focusing on reorganizing imports and addressing a CSV field size limit issue. The key updates include reordering and cleaning up imports for better organization and adding a fix to prevent CSV field size limit errors.

### Import Reorganization:
* Reordered imports to follow a logical grouping, such as standard library imports, third-party libraries, and local modules, improving code readability. Some unused imports were removed, and others were reintroduced in a different order (`Client`, `Tables`, `Configuration`, etc.).

### CSV Field Size Limit Fix:
* Added a call to `csv.field_size_limit(sys.maxsize)` to prevent "field larger than field limit" errors when processing large CSV files. This change includes a comment linking to relevant documentation for context.