### PR TITLE
Support 12268 Filtering None response from llm

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -199,7 +199,16 @@ class Component(ComponentBase):
             tasks.append(self._infer(client, row, prompt))
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        return [r for r in results if r is not None]
+
+        processed_results = []
+        for i, res in enumerate(results):
+            if res is None:
+                logging.warning(f"Task for row {rows[i]} resulted in a None result. Prompt: '{prompts[i]}'")
+            elif isinstance(res, BaseException):
+                logging.error(f"Task for row {rows[i]} failed with an exception: {res}")
+            else:
+                processed_results.append(res)
+        return processed_results
 
     async def _infer(self, client, row, prompt):
 

--- a/src/component.py
+++ b/src/component.py
@@ -200,11 +200,7 @@ class Component(ComponentBase):
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        processed_results = []
-        for res in results:
-            if res is not None:
-                processed_results.append(res)
-        return processed_results
+        return [r for r in results if r is not None]
 
     async def _infer(self, client, row, prompt):
 

--- a/src/component.py
+++ b/src/component.py
@@ -198,7 +198,8 @@ class Component(ComponentBase):
         for row, prompt in zip(rows, prompts):
             tasks.append(self._infer(client, row, prompt))
 
-        return await asyncio.gather(*tasks)
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        return [r for r in results if r is not None]
 
     async def _infer(self, client, row, prompt):
 
@@ -224,6 +225,7 @@ class Component(ComponentBase):
         if result:
             return self._build_output_row(row, result)
         else:
+            logging.warning(f"Empty result received for row {row}")
             self.failed_requests += 1
 
     def prepare_tables(self):

--- a/src/component.py
+++ b/src/component.py
@@ -201,12 +201,8 @@ class Component(ComponentBase):
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         processed_results = []
-        for i, res in enumerate(results):
-            if res is None:
-                logging.warning(f"Task for row {rows[i]} resulted in a None result. Prompt: '{prompts[i]}'")
-            elif isinstance(res, BaseException):
-                logging.error(f"Task for row {rows[i]} failed with an exception: {res}")
-            else:
+        for res in results:
+            if res is not None:
                 processed_results.append(res)
         return processed_results
 


### PR DESCRIPTION
In special cases (e.g. many empty HTML tags like &nbsp;), the LLM may return an empty response. This PR adds better logging and filters out None results more reliably.

Ticket: https://keboola.atlassian.net/browse/SUPPORT-12268